### PR TITLE
Fix"-no-color" and "-json" options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <revision>0.7.0</revision>
+    <revision>0.7.1</revision>
     <sonar.organization>azbuilder</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <maven.deploy.skip>true</maven.deploy.skip>

--- a/terraform-client/pom.xml
+++ b/terraform-client/pom.xml
@@ -23,7 +23,7 @@
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.4.0</maven-javadoc-plugin.version>
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
-        <revision>0.7.0</revision>
+        <revision>0.7.1</revision>
         <maven.deploy.skip>false</maven.deploy.skip>
         <commons-io.version>2.11.0</commons-io.version>
         <maven-artifact.version>3.8.1</maven-artifact.version>

--- a/terraform-client/src/main/java/org/terrakube/terraform/TerraformClient.java
+++ b/terraform-client/src/main/java/org/terrakube/terraform/TerraformClient.java
@@ -256,6 +256,22 @@ public class TerraformClient implements AutoCloseable {
             }
 
         ComparableVersion version = new ComparableVersion(terraformVersion);
+
+        if (!this.showColor)
+            launcher.appendCommands(TERRAFORM_PARAM_NO_COLOR);
+
+        //https://www.terraform.io/docs/internals/machine-readable-ui.html
+        if (this.jsonOutput && version.compareTo(new ComparableVersion("0.15.2")) > 0)
+            switch (command) {
+                case plan:
+                case apply:
+                case destroy:
+                    launcher.appendCommands(TERRAFORM_PARAM_JSON);
+                    break;
+                default:
+                    break;
+            }
+
         switch (command) {
             case init:
                 if (terraformBackendConfigFileName != null) {
@@ -312,21 +328,6 @@ public class TerraformClient implements AutoCloseable {
             default:
                 break;
         }
-
-        if (!this.showColor)
-            launcher.appendCommands(TERRAFORM_PARAM_NO_COLOR);
-
-        //https://www.terraform.io/docs/internals/machine-readable-ui.html
-        if (this.jsonOutput && version.compareTo(new ComparableVersion("0.15.2")) > 0)
-            switch (command) {
-                case plan:
-                case apply:
-                case destroy:
-                    launcher.appendCommands(TERRAFORM_PARAM_JSON);
-                    break;
-                default:
-                    break;
-            }
 
         launcher.setOutputListener(outputListener);
         launcher.setErrorListener(errorListener);

--- a/terraform-spring-boot-autoconfigure/pom.xml
+++ b/terraform-spring-boot-autoconfigure/pom.xml
@@ -22,7 +22,7 @@
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-javadoc-plugin.version>3.4.0</maven-javadoc-plugin.version>
     <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
-    <revision>0.7.0</revision>
+    <revision>0.7.1</revision>
     <maven.deploy.skip>false</maven.deploy.skip>
     <lombok.version>1.18.20</lombok.version>
   </properties>

--- a/terraform-spring-boot-samples/pom.xml
+++ b/terraform-spring-boot-samples/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <revision>0.7.0</revision>
+        <revision>0.7.1</revision>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 

--- a/terraform-spring-boot-samples/raw-client-library-sample/pom.xml
+++ b/terraform-spring-boot-samples/raw-client-library-sample/pom.xml
@@ -20,7 +20,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <revision>0.7.0</revision>
+        <revision>0.7.1</revision>
     </properties>
 
     <licenses>

--- a/terraform-spring-boot-samples/spring-starter-sample/pom.xml
+++ b/terraform-spring-boot-samples/spring-starter-sample/pom.xml
@@ -20,7 +20,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <revision>0.7.0</revision>
+        <revision>0.7.1</revision>
     </properties>
 
     <licenses>

--- a/terraform-spring-boot-starter/pom.xml
+++ b/terraform-spring-boot-starter/pom.xml
@@ -17,7 +17,7 @@
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-javadoc-plugin.version>3.4.0</maven-javadoc-plugin.version>
     <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
-    <revision>0.7.0</revision>
+    <revision>0.7.1</revision>
     <maven.deploy.skip>false</maven.deploy.skip>
   </properties>
 


### PR DESCRIPTION
Fixes #25 

This will fix the issue with the param order for "-no-color" and "-json" options when creating the terraform client like the following example:

```java
        TerraformClient terraformClient = TerraformClient
                .builder()
                .environmentVariables(new HashMap<>())
                .terraformParameters(new HashMap<>())
                .terraformVersion("1.2.9")
                .jsonOutput(true)
                .showColor(false)
                .errorListener(System.err::println)
                .outputListener(System.out::println)
                .build();
```

Example:

### Plan

![image](https://user-images.githubusercontent.com/4461895/218498880-a0cb4ec1-107e-478e-9caf-afc0bc20c77f.png)

### Apply

![image](https://user-images.githubusercontent.com/4461895/218498951-1ed557f7-c879-4896-8c34-c86b7d8622a8.png)

### Destroy

![image](https://user-images.githubusercontent.com/4461895/218499030-a8222008-21ed-4180-bb10-758adf36f854.png)

