### PR TITLE
Add SSH key location support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <revision>0.9.1</revision>
+    <revision>0.10.0</revision>
     <sonar.organization>azbuilder</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <maven.deploy.skip>true</maven.deploy.skip>

--- a/terraform-client/pom.xml
+++ b/terraform-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.9</version>
+        <version>2.7.11</version>
     </parent>
 
     <groupId>org.terrakube.terraform</groupId>
@@ -23,7 +23,7 @@
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.4.0</maven-javadoc-plugin.version>
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
-        <revision>0.9.1</revision>
+        <revision>0.10.0</revision>
         <maven.deploy.skip>false</maven.deploy.skip>
         <commons-io.version>2.11.0</commons-io.version>
         <maven-artifact.version>3.8.1</maven-artifact.version>

--- a/terraform-client/src/main/java/org/terrakube/terraform/TerraformClient.java
+++ b/terraform-client/src/main/java/org/terrakube/terraform/TerraformClient.java
@@ -386,12 +386,12 @@ public class TerraformClient implements AutoCloseable {
             }
 
         if (!this.showColor)
-            initSSHCommand.join("", TERRAFORM_PARAM_NO_COLOR);
+            initSSHCommand = initSSHCommand.join("", TERRAFORM_PARAM_NO_COLOR);
 
         if (terraformProcessData.getTerraformBackendConfigFileName() != null) {
-            initSSHCommand.join(" ", TERRAFORM_PARAM_BACKEND.concat(terraformProcessData.getTerraformBackendConfigFileName()));
+            initSSHCommand = initSSHCommand.join(" ", TERRAFORM_PARAM_BACKEND.concat(terraformProcessData.getTerraformBackendConfigFileName()));
         }
-        initSSHCommand.join(" ", TERRAFORM_PARAM_DISABLE_USER_INPUT);
+        initSSHCommand = initSSHCommand.join(" ", TERRAFORM_PARAM_DISABLE_USER_INPUT);
 
         log.warn("Running terraform init with command {},", initSSHCommand);
         processLauncher.appendCommands(initSSHCommand);

--- a/terraform-client/src/main/java/org/terrakube/terraform/TerraformClient.java
+++ b/terraform-client/src/main/java/org/terrakube/terraform/TerraformClient.java
@@ -261,8 +261,14 @@ public class TerraformClient implements AutoCloseable {
 
     private ProcessLauncher getTerraformLauncher(TerraformProcessData terraformProcessData, Consumer<String> outputListener, Consumer<String> errorListener, TerraformCommand command) throws IOException {
         TerraformDownloader terraformDownloader = createTerraformDownloader();
+        String terraformPath = terraformDownloader.downloadTerraformVersion(terraformProcessData.getTerraformVersion());
 
-        ProcessLauncher launcher = new ProcessLauncher(this.executor, terraformDownloader.downloadTerraformVersion(terraformProcessData.getTerraformVersion()), command.getLabel());
+        if (terraformProcessData.sshFile != null && command.equals(TerraformCommand.init)) {
+            return getTerraformInitWithSSH(terraformPath, terraformProcessData, outputListener, errorListener);
+        }
+
+        ProcessLauncher launcher = new ProcessLauncher(this.executor, terraformPath, command.getLabel());
+
         launcher.setDirectory(terraformProcessData.getWorkingDirectory());
         launcher.setInheritIO(this.isInheritIO());
 
@@ -366,6 +372,33 @@ public class TerraformClient implements AutoCloseable {
         launcher.setOutputListener(outputListener);
         launcher.setErrorListener(errorListener);
         return launcher;
+    }
+
+    private ProcessLauncher getTerraformInitWithSSH(String terraformPath, TerraformProcessData terraformProcessData, Consumer<String> outputListener, Consumer<String> errorListener) {
+        String initSSHCommand = String.format("GIT_SSH_COMMAND='ssh -i %s -o StrictHostKeyChecking=no' %s init", terraformProcessData.getSshFile().getAbsolutePath(), terraformPath);
+        ProcessLauncher processLauncher = new ProcessLauncher(this.executor, "bash", "-c");
+        processLauncher.setInheritIO(this.isInheritIO());
+        processLauncher.setDirectory(terraformProcessData.getWorkingDirectory());
+
+        if (terraformProcessData.getTerraformEnvironmentVariables() != null)
+            for (Map.Entry<String, String> entry : terraformProcessData.getTerraformEnvironmentVariables().entrySet()) {
+                processLauncher.setEnvironmentVariable(entry.getKey(), entry.getValue());
+            }
+
+        if (!this.showColor)
+            initSSHCommand.join("", TERRAFORM_PARAM_NO_COLOR);
+
+        if (terraformProcessData.getTerraformBackendConfigFileName() != null) {
+            initSSHCommand.join(" ", TERRAFORM_PARAM_BACKEND.concat(terraformProcessData.getTerraformBackendConfigFileName()));
+        }
+        initSSHCommand.join(" ", TERRAFORM_PARAM_DISABLE_USER_INPUT);
+
+        log.warn("Running terraform init with command {},", initSSHCommand);
+        processLauncher.appendCommands(initSSHCommand);
+        processLauncher.setOutputListener(outputListener);
+        processLauncher.setErrorListener(errorListener);
+
+        return processLauncher;
     }
 
     public TerraformDownloader createTerraformDownloader() {

--- a/terraform-client/src/main/java/org/terrakube/terraform/TerraformProcessData.java
+++ b/terraform-client/src/main/java/org/terrakube/terraform/TerraformProcessData.java
@@ -14,6 +14,7 @@ public class TerraformProcessData {
     @NonNull File workingDirectory;
     String terraformBackendConfigFileName;
     String varFileName;
+    File sshFile;
     @Singular Map<String, String> terraformVariables;
     @Singular Map<String, String> terraformEnvironmentVariables;
 }

--- a/terraform-spring-boot-autoconfigure/pom.xml
+++ b/terraform-spring-boot-autoconfigure/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.9</version>
+    <version>2.7.11</version>
   </parent>
 
   <groupId>org.terrakube.terraform</groupId>
@@ -22,7 +22,7 @@
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-javadoc-plugin.version>3.4.0</maven-javadoc-plugin.version>
     <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
-    <revision>0.9.1</revision>
+    <revision>0.10.0</revision>
     <maven.deploy.skip>false</maven.deploy.skip>
     <lombok.version>1.18.20</lombok.version>
   </properties>

--- a/terraform-spring-boot-samples/pom.xml
+++ b/terraform-spring-boot-samples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.9</version>
+        <version>2.7.11</version>
     </parent>
 
     <groupId>org.terrakube.terraform</groupId>
@@ -18,7 +18,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <revision>0.9.1</revision>
+        <revision>0.10.0</revision>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 

--- a/terraform-spring-boot-samples/raw-client-library-sample/pom.xml
+++ b/terraform-spring-boot-samples/raw-client-library-sample/pom.xml
@@ -20,7 +20,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <revision>0.9.1</revision>
+        <revision>0.10.0</revision>
     </properties>
 
     <licenses>

--- a/terraform-spring-boot-samples/spring-starter-sample/pom.xml
+++ b/terraform-spring-boot-samples/spring-starter-sample/pom.xml
@@ -20,7 +20,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <revision>0.9.1</revision>
+        <revision>0.10.0</revision>
     </properties>
 
     <licenses>

--- a/terraform-spring-boot-starter/pom.xml
+++ b/terraform-spring-boot-starter/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.9</version>
+    <version>2.7.11</version>
   </parent>
 
   <groupId>org.terrakube.terraform</groupId>
@@ -17,7 +17,7 @@
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-javadoc-plugin.version>3.4.0</maven-javadoc-plugin.version>
     <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
-    <revision>0.9.1</revision>
+    <revision>0.10.0</revision>
     <maven.deploy.skip>false</maven.deploy.skip>
   </properties>
 


### PR DESCRIPTION
Sometimes when using Terraform modules from a private repository, we need to specify the SSH key location
Example:
```terraform
module "test" {
  source = "git@bitbucket.org:alfespa17/private-module.git"
}
```

The following command can be used to set the SSH key location when executing terraform in the linux CLI:

```bash
GIT_SSH_COMMAND="ssh -i /home/user/customSSH/id_rsa -o StrictHostKeyChecking=no" terraform init
```

The library can handle the ssh key location like the following example, internally it will run the above command:

```java
package org.terrakube.terraform;

import java.io.File;
import java.io.IOException;
import java.util.concurrent.ExecutionException;

public class Main {

    public static void main(String[] args) throws IOException, ExecutionException, InterruptedException {
        testSSH();
    }

    public static void testSSH(){
        String terraformVersion="1.4.6";
        TerraformClient terraformClient = TerraformClient
                .builder()
                .jsonOutput(false)
                .showColor(false)
                .build();
        try {
            File workingDirectory = new File("/home/user/my-modules/terraform-modules");

            TerraformProcessData terraformProcessData = TerraformProcessData.builder()
                    .terraformVersion(terraformVersion)
                    .workingDirectory(workingDirectory)
                    .sshFile(new File("/home/user/customSSH/id_rsa"))
                    .build();

            terraformClient.init(terraformProcessData, System.out::println, System.err::println).get();

        } catch (IOException | ExecutionException | InterruptedException exception) {
            exception.printStackTrace();
        }
    }
}

```