### PR TITLE
Allow environment variables when running terraform init

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <revision>0.11.0</revision>
+    <revision>0.11.1</revision>
     <sonar.organization>azbuilder</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <maven.deploy.skip>true</maven.deploy.skip>

--- a/terraform-client/pom.xml
+++ b/terraform-client/pom.xml
@@ -23,7 +23,7 @@
         <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.6.2</maven-javadoc-plugin.version>
         <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
-        <revision>0.11.0</revision>
+        <revision>0.11.1</revision>
         <maven.deploy.skip>false</maven.deploy.skip>
         <commons-io.version>2.15.0</commons-io.version>
         <maven-artifact.version>3.9.5</maven-artifact.version>

--- a/terraform-client/src/main/java/org/terrakube/terraform/TerraformClient.java
+++ b/terraform-client/src/main/java/org/terrakube/terraform/TerraformClient.java
@@ -75,7 +75,6 @@ public class TerraformClient implements AutoCloseable {
 
     public CompletableFuture<Boolean> show() throws IOException {
         this.checkRunningParameters();
-
         return this.run(TerraformCommand.show);
     }
 

--- a/terraform-client/src/main/java/org/terrakube/terraform/TerraformClient.java
+++ b/terraform-client/src/main/java/org/terrakube/terraform/TerraformClient.java
@@ -66,7 +66,6 @@ public class TerraformClient implements AutoCloseable {
     public CompletableFuture<Boolean> show(@NonNull TerraformProcessData terraformProcessData, @NonNull Consumer<String> outputListener, @NonNull Consumer<String> errorListener) throws IOException {
         checkVarFileParam(terraformProcessData);
         checkTerraformVariablesParam(terraformProcessData);
-        checkTerraformEnvVariablesParam(terraformProcessData);
         return this.run(
                 terraformProcessData,
                 outputListener,
@@ -76,13 +75,13 @@ public class TerraformClient implements AutoCloseable {
 
     public CompletableFuture<Boolean> show() throws IOException {
         this.checkRunningParameters();
+
         return this.run(TerraformCommand.show);
     }
 
     public CompletableFuture<Boolean> showPlan(@NonNull TerraformProcessData terraformProcessData, @NonNull Consumer<String> outputListener, @NonNull Consumer<String> errorListener) throws IOException {
         checkVarFileParam(terraformProcessData);
         checkTerraformVariablesParam(terraformProcessData);
-        checkTerraformEnvVariablesParam(terraformProcessData);
         return this.run(
                 terraformProcessData,
                 outputListener,
@@ -98,7 +97,6 @@ public class TerraformClient implements AutoCloseable {
     public CompletableFuture<Boolean> init(TerraformProcessData terraformProcessData, @NonNull Consumer<String> outputListener, @NonNull Consumer<String> errorListener) throws IOException {
         checkVarFileParam(terraformProcessData);
         checkTerraformVariablesParam(terraformProcessData);
-        checkTerraformEnvVariablesParam(terraformProcessData);
         return this.run(
                 terraformProcessData,
                 outputListener,

--- a/terraform-client/src/main/java/org/terrakube/terraform/TerraformClient.java
+++ b/terraform-client/src/main/java/org/terrakube/terraform/TerraformClient.java
@@ -161,7 +161,6 @@ public class TerraformClient implements AutoCloseable {
         checkBackendConfigFile(terraformProcessData);
         checkVarFileParam(terraformProcessData);
         checkTerraformVariablesParam(terraformProcessData);
-        checkTerraformEnvVariablesParam(terraformProcessData);
         return this.run(
                 terraformProcessData,
                 outputListener,

--- a/terraform-spring-boot-autoconfigure/pom.xml
+++ b/terraform-spring-boot-autoconfigure/pom.xml
@@ -22,7 +22,7 @@
     <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
     <maven-javadoc-plugin.version>3.6.2</maven-javadoc-plugin.version>
     <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
-    <revision>0.11.0</revision>
+    <revision>0.11.1</revision>
     <maven.deploy.skip>false</maven.deploy.skip>
     <lombok.version>1.18.30</lombok.version>
     <maven.compiler.source>11</maven.compiler.source>

--- a/terraform-spring-boot-samples/pom.xml
+++ b/terraform-spring-boot-samples/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <revision>0.11.0</revision>
+        <revision>0.11.1</revision>
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/terraform-spring-boot-samples/raw-client-library-sample/pom.xml
+++ b/terraform-spring-boot-samples/raw-client-library-sample/pom.xml
@@ -20,7 +20,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <revision>0.11.0</revision>
+        <revision>0.11.1</revision>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
     </properties>

--- a/terraform-spring-boot-samples/spring-starter-sample/pom.xml
+++ b/terraform-spring-boot-samples/spring-starter-sample/pom.xml
@@ -20,7 +20,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <revision>0.11.0</revision>
+        <revision>0.11.1</revision>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
     </properties>

--- a/terraform-spring-boot-starter/pom.xml
+++ b/terraform-spring-boot-starter/pom.xml
@@ -17,7 +17,7 @@
     <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
     <maven-javadoc-plugin.version>3.6.2</maven-javadoc-plugin.version>
     <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
-    <revision>0.11.0</revision>
+    <revision>0.11.1</revision>
     <maven.deploy.skip>false</maven.deploy.skip>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>


### PR DESCRIPTION
Allow adding environment variables when running terraform commands like init, this is useful when you want to add env variables like TF_TOKEN_app_terraform_io to handle the authorization with the terraform registry

Fix #39 