### PR TITLE
fix: wait for output stream readers before completing process exit future

### DIFF
--- a/terraform-client/pom.xml
+++ b/terraform-client/pom.xml
@@ -184,6 +184,12 @@
             <artifactId>semver4j</artifactId>
             <version>6.0.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/terraform-client/src/main/java/io/terrakube/terraform/ProcessLauncher.java
+++ b/terraform-client/src/main/java/io/terrakube/terraform/ProcessLauncher.java
@@ -7,6 +7,8 @@ import java.util.function.*;
 import java.util.stream.*;
 
 public final class ProcessLauncher {
+    private static final long STREAM_DRAIN_TIMEOUT_SECONDS = 60;
+
     private Process process;
     private ProcessBuilder builder;
     private Consumer<String> outputListener, errorListener;
@@ -75,22 +77,50 @@ public final class ProcessLauncher {
         } catch (IOException ex) {
             throw new RuntimeException(ex);
         }
+        Future<Boolean> outputDrained = null;
+        Future<Boolean> errorDrained = null;
         if (!this.inheritIO) {
             if (this.outputListener != null) {
-                this.executor.submit(() -> this.readProcessStream(this.process.getInputStream(), this.outputListener));
+                outputDrained = this.executor.submit(() -> this.readProcessStream(this.process.getInputStream(), this.outputListener));
             }
             if (this.errorListener != null) {
-                this.executor.submit(() -> this.readProcessStream(this.process.getErrorStream(), this.errorListener));
+                errorDrained = this.executor.submit(() -> this.readProcessStream(this.process.getErrorStream(), this.errorListener));
             }
         }
+        final Future<Boolean> outputDone = outputDrained;
+        final Future<Boolean> errorDone = errorDrained;
         return CompletableFuture.supplyAsync(() -> {
             try {
-                return this.process.waitFor();
+                int exitCode = this.process.waitFor();
+                // Wait for the reader tasks to finish draining the process
+                // output before completing, so callers never observe the exit
+                // code while the listeners have received only part (or none)
+                // of the output. The readers were submitted before this task
+                // and read until EOF, so after process exit they only have
+                // the remaining pipe buffer left to deliver; the timeout is a
+                // safety net that turns a wedged reader into a visible
+                // failure instead of silently missing output.
+                awaitStreamDrained(outputDone, "output");
+                awaitStreamDrained(errorDone, "error");
+                return exitCode;
             } catch (InterruptedException ex) {
                 Thread.currentThread().interrupt();
                 throw new RuntimeException(ex);
             }
         }, this.executor);
+    }
+
+    private void awaitStreamDrained(Future<Boolean> drained, String streamName) throws InterruptedException {
+        if (drained == null) {
+            return;
+        }
+        try {
+            if (!drained.get(STREAM_DRAIN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                throw new RuntimeException(String.format("Failed to capture process %s stream", streamName));
+            }
+        } catch (ExecutionException | TimeoutException ex) {
+            throw new RuntimeException(String.format("Failed to capture process %s stream", streamName), ex);
+        }
     }
 
     private boolean readProcessStream(InputStream stream, Consumer<String> listener) {

--- a/terraform-client/src/test/java/io/terrakube/terraform/ProcessLauncherTest.java
+++ b/terraform-client/src/test/java/io/terrakube/terraform/ProcessLauncherTest.java
@@ -1,0 +1,86 @@
+package io.terrakube.terraform;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DisabledOnOs(OS.WINDOWS)
+class ProcessLauncherTest {
+
+    private static final ExecutorService POOL = Executors.newWorkStealingPool();
+
+    @AfterAll
+    static void shutdownPool() {
+        POOL.shutdown();
+    }
+
+    /**
+     * Regression test: the exit-code future returned by launch() must not
+     * complete before the output listeners have received the complete
+     * process output. Previously the stream reader tasks and the waitFor()
+     * future were submitted to the pool independently and never joined, so a
+     * caller could observe a successful exit code while the listener had
+     * received only part (or none) of the output. TerraformClient callers
+     * such as showPlanJson() snapshot the collected output immediately after
+     * the future completes, which intermittently produced blank plan JSON
+     * (terrakube-io/terrakube#3294).
+     *
+     * The output (200k lines, ~1.4 MB) is intentionally much larger than the
+     * OS pipe buffer so a non-joined reader is very likely to still be
+     * draining when waitFor() returns.
+     */
+    @Test
+    void outputIsFullyCapturedWhenExitCodeFutureCompletes() throws Exception {
+        final int expectedLines = 200_000;
+        for (int run = 0; run < 20; run++) {
+            AtomicLong lines = new AtomicLong();
+            ProcessLauncher launcher = new ProcessLauncher(POOL, "bash", "-c", "seq 1 " + expectedLines);
+            launcher.setOutputListener(line -> lines.incrementAndGet());
+            launcher.setErrorListener(line -> {
+            });
+            int exitCode = launcher.launch().get();
+
+            assertEquals(0, exitCode, "process should exit cleanly on run " + run);
+            assertEquals(expectedLines, lines.get(),
+                    "listener should have received the complete output when the exit-code future completes (run " + run + ")");
+        }
+    }
+
+    @Test
+    void errorStreamIsFullyCapturedWhenExitCodeFutureCompletes() throws Exception {
+        final int expectedLines = 50_000;
+        AtomicLong lines = new AtomicLong();
+        ProcessLauncher launcher = new ProcessLauncher(POOL, "bash", "-c", "seq 1 " + expectedLines + " 1>&2");
+        launcher.setOutputListener(line -> {
+        });
+        launcher.setErrorListener(line -> lines.incrementAndGet());
+        int exitCode = launcher.launch().get();
+
+        assertEquals(0, exitCode);
+        assertEquals(expectedLines, lines.get(),
+                "error listener should have received the complete stderr output when the exit-code future completes");
+    }
+
+    @Test
+    void exitCodeIsStillReportedForFailingProcess() throws Exception {
+        ProcessLauncher launcher = new ProcessLauncher(POOL, "bash", "-c", "echo out; echo err 1>&2; exit 3");
+        List<String> output = new ArrayList<>();
+        List<String> error = new ArrayList<>();
+        launcher.setOutputListener(output::add);
+        launcher.setErrorListener(error::add);
+        int exitCode = launcher.launch().get();
+
+        assertEquals(3, exitCode);
+        assertEquals(List.of("out"), output);
+        assertEquals(List.of("err"), error);
+    }
+}


### PR DESCRIPTION

Fixes the root cause of terrakube-io/terrakube#3294 (structured plan output intermittently missing), as discussed there with @alfespa17.

### Problem

`ProcessLauncher.launch()` submits the stdout/stderr reader tasks and the `process.waitFor()` future to the executor independently and never joins the readers:

```java
this.executor.submit(() -> this.readProcessStream(this.process.getInputStream(), this.outputListener));
this.executor.submit(() -> this.readProcessStream(this.process.getErrorStream(), this.errorListener));
return CompletableFuture.supplyAsync(() -> this.process.waitFor(), this.executor);
```

The exit-code future can therefore complete while a reader is still draining the pipe. Callers that snapshot the collected output right after the future completes — e.g. `TerraformClient.showPlanJson()`, whose consumers append into a `TextStringBuilder` and read it immediately after `.get()` — intermittently observe a successful exit code with **partial or completely empty output**. `readProcessStream` additionally swallows `IOException` (`return false` is never observed), so a broken reader loses output with no trace.

In Terrakube this surfaced as structured plan output silently missing: `terraform`/`tofu show -json` emits the plan as one long line, so the captured output is either complete or entirely blank depending on which side of the race the run lands on — and blank plan JSON is skipped without logging by `PlanStructuredOutputService`.

### Fix

`launch()` keeps the `Future`s of both reader tasks and, after `waitFor()` returns, waits for them to finish draining (60s safety timeout) before completing the exit-code future. The readers are submitted before the waitFor task and read until EOF, so post-exit they only have the remaining pipe buffer left to deliver — the join is cheap. A reader that failed with an `IOException` (previously swallowed) now fails the future with `Failed to capture process output/error stream` instead of silently losing output.

### Numbers

Stress harness: `bash -c "seq 1 200000"` (~1.4 MB, far beyond the pipe buffer), counting listener callbacks at the moment `launch().get()` returns:

| Version | Runs with complete output at future completion |
|---|---|
| current master | **5 / 100** (worst run missing ~8,000 lines) |
| this PR | **100 / 100** |

### Tests

Adds `ProcessLauncherTest` (first tests in `terraform-client`, `junit-jupiter` test-scope dependency version-managed by the Spring Boot parent):

- `outputIsFullyCapturedWhenExitCodeFutureCompletes` — 20 runs × 200k lines; reliably red on current master, green with the fix
- `errorStreamIsFullyCapturedWhenExitCodeFutureCompletes`
- `exitCodeIsStillReportedForFailingProcess` — non-zero exit codes still propagate with their output

(Tests use `bash`/`seq`, so they're `@DisabledOnOs(WINDOWS)`; CI runs ubuntu-latest.)

### Verification in production

The equivalent patch (compiled class shadowed via `BOOT-INF/classes` over `terraform-client-1.4.0.jar`) has been running on the production Terrakube instance from #3294: the workspace that previously skipped structured output silently now saves the full `planStructuredOutput` context on every plan.
